### PR TITLE
o.c.utility.pvmanager.jdbc: Fix oracle access

### DIFF
--- a/pvmanager/plugins/org.csstudio.utility.pvmanager.jdbc/pom.xml
+++ b/pvmanager/plugins/org.csstudio.utility.pvmanager.jdbc/pom.xml
@@ -60,7 +60,7 @@
 						<Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
 						<Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
 						<Export-Package>org.epics.pvmanager.jdbc</Export-Package>
-						<Import-Package>com.mysql.jdbc,org.postgresql,oracle.jdbc.driver,*;ui.workbench=!;common=!;registry=!;texteditor=!;text=!</Import-Package>
+						<Import-Package>com.mysql.jdbc,org.postgresql,oracle.jdbc,*;ui.workbench=!;common=!;registry=!;texteditor=!;text=!</Import-Package>
 						<_snapshot>${maven.build.timestamp}</_snapshot>
 					</instructions>
 				</configuration>


### PR DESCRIPTION
Only oracle.jdbc.driver package was accessible, not oracle.jdbc, which
prevented connecting with oracle.jdbc.OracleDriver.

Fixes https://github.com/ControlSystemStudio/cs-studio/issues/870