### PR TITLE
Jython: unpack, install a 'dir'

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -161,6 +161,7 @@
 										<Bundle-SymbolicName>org.python.jython</Bundle-SymbolicName>
 										<Bundle-Version>2.7.0.release</Bundle-Version>
 										<Export-Package>org.python.*,</Export-Package>
+										<Eclipse-BundleShape>dir</Eclipse-BundleShape>
 										<Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
 									</instructions>	
 								</artifact>


### PR DESCRIPTION
.. because loading Jython is faster when standard *.py modules don't need to be un-zipped

See https://github.com/ControlSystemStudio/cs-studio/issues/1674

