### PR TITLE
Remove SLF4J

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -98,21 +98,6 @@
 									<id>org.apache.ant:ant-junit:1.9.4</id>
 								</artifact>
 								<artifact>
-									<id>org.slf4j:jul-to-slf4j:1.7.2</id>
-								</artifact>
-								<artifact>
-									<id>org.slf4j:log4j-over-slf4j:1.5.11</id>
-								</artifact>
-								<artifact>
-									<id>org.slf4j:slf4j-api:1.7.7</id>
-								</artifact>
-								<artifact>
-									<id>org.slf4j:slf4j-log4j12:1.7.7</id>
-								</artifact>
-								<artifact>
-									<id>org.slf4j:jul-to-slf4j:1.7.7</id>
-								</artifact>
-								<artifact>
 									<id>net.sf.ehcache.internal:ehcache-core:2.8.3</id>
 								</artifact>
 								<artifact>


### PR DESCRIPTION
Remove Log4J to reduce the number of logging libraries,
https://github.com/ControlSystemStudio/cs-studio/issues/1668
cs-studio core, apps and SNS products built OK w/o Log4J.