### PR TITLE
Medusa removed in favour of a new plug-in inside cs-studio-thirdparty.

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -245,9 +245,6 @@
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>eu.hansolo:Medusa:7.6</id>
-                </artifact>
-                <artifact>
                   <id>org.controlsfx:controlsfx:8.40.12</id>
                 </artifact>
 


### PR DESCRIPTION
Due to the many changes I’ve made to the Medusa library and the time
often required before their integration into the master branch and
publishing to Maven central, I’ve opted to a new plug-in into
cs-studio-thirdparty.

This will ease the transition from Medusa to a different project I’m
about to open (based on Medusa code).

**NOTE:** this pull-request is required to proceed with [org.csstudio.display.builder#217](https://github.com/kasemir/org.csstudio.display.builder/pull/217).