### PR TITLE
Added support for SVG in JavaFX.

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -250,7 +250,9 @@
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.12</id>
                 </artifact>
-
+                <artifact>
+                  <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
+                </artifact>
 
                 <!-- pvmanager-plugins from reactor -->
                 <artifact>


### PR DESCRIPTION
Added the [JavaFxSVG](https://github.com/codecentric/javafxsvg) library providing a [custom image renderer to JavaFX 8](https://blog.codecentric.de/en/2015/03/adding-custom-image-renderer-javafx-8/) supporting SVG images.