### PR TITLE
Influxdb fix

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -168,7 +168,7 @@
                 <artifact>
                   <id>org.influxdb:influxdb-java:2.6</id>
 		  <instructions>
-		    <Require-Bundle>com.squareup.retrofit2.converter-moshi</Require-Bundle>
+		    <Require-Bundle>com.squareup.retrofit2.converter-moshi,com.squareup.okhttp3.logging-interceptor</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -167,6 +167,9 @@
                 </artifact>
                 <artifact>
                   <id>org.influxdb:influxdb-java:2.6</id>
+		  <instructions>
+		    <Require-Bundle>com.squareup.retrofit2.converter-moshi</Require-Bundle>
+                  </instructions>
                 </artifact>
                 <artifact>
                   <id>org.glassfish:javax.json:1.0.4</id>


### PR DESCRIPTION
This change to the repository pom file fixes and issue where the influxdb-2.6 bundle does not generate the correct dependencies in the manifest. The changes manually add the two missing dependencies required for using the influxdb CSS plugins.