### PR TITLE
Ess libraries on maven

### DIFF
--- a/epics/plugins/org.csstudio.platform.libs.epics/.classpath
+++ b/epics/plugins/org.csstudio.platform.libs.epics/.classpath
@@ -23,11 +23,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="target/sources">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -256,11 +256,22 @@
                     <Bundle-Version>1.5.8.css1</Bundle-Version>
                   </instructions>
                 </artifact>
+
+
                 <artifact>
-                  <id>org.controlsfx:controlsfx:8.40.12</id>
+                  <id>org.controlsfx:controlsfx:8.40.14</id>
                 </artifact>
                 <artifact>
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
+                </artifact>
+                <artifact>
+                  <id>se.europeanspallationsource:javafx.control.knobs:1.0.11</id>
+                </artifact>
+                <artifact>
+                  <id>se.europeanspallationsource:javafx.control.medusa:7.9.7</id>
+                </artifact>
+                <artifact>
+                  <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>
                 </artifact>
 
                 <!-- pvmanager-plugins from reactor -->

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -265,6 +265,9 @@
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
                 </artifact>
                 <artifact>
+                  <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.4</id>
+                </artifact>
+                <artifact>
                   <id>se.europeanspallationsource:javafx.control.knobs:1.0.11</id>
                 </artifact>
                 <artifact>


### PR DESCRIPTION
To allow the phoebus version of Display builder to access the libraries currently available in `cs-studio-thirdparty`, I've published the JavaFX controllers made or contributed by ESS to Maven Central.

Updated:

- org.controlsfx:controlsfx:8.40.14

Added:

- se.europeanspallationsource:javafx.control.controlled-knobs:1.0.4
- se.europeanspallationsource:javafx.control.knobs:1.0.11
- se.europeanspallationsource:javafx.control.medusa:7.9.7
- se.europeanspallationsource:javafx.control.thumbwheel:1.0.3
