### PR TITLE
CSSTUDIO-603: SVG loaded with bad size

### DIFF
--- a/epics/plugins/org.csstudio.platform.libs.epics/.classpath
+++ b/epics/plugins/org.csstudio.platform.libs.epics/.classpath
@@ -23,11 +23,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="target/sources">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -261,6 +261,14 @@
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.14</id>
                 </artifact>
+<!--
+	Not possible to use JavaFxSVG 1.3.0 with the new instantiaion method
+		SvgImageLoaderFactory.install(new PrimitiveDimensionProvider());
+	because of conflicts loading org.apache.batic... classes
+		Exception ... java.lang.NoClassDefFoundError: org/apache/batik/dom/svg/SVGDocumentFactory
+		Caused by: java.lang.ClassNotFoundException: org.apache.batik.dom.svg.SVGDocumentFactory cannot be found by org.apache.xmlgraphics.batik-anim_1.8.0
+	because of coexistence of ver. 1.7 and 1.8 of org.apache.batik.dom.svg.
+-->
                 <artifact>
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
                 </artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -265,6 +265,21 @@
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
                 </artifact>
                 <artifact>
+                  <id>org.reactfx:reactfx:2.0-M5</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.flowless:flowless:0.6</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.richtext:richtextfx:0.8.1</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.undo:undofx:1.3.1</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.wellbehaved:wellbehavedfx:0.3</id>
+                </artifact>
+                <artifact>
                   <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.4</id>
                 </artifact>
                 <artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -250,7 +250,9 @@
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.12</id>
                 </artifact>
-
+                <artifact>
+                  <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
+                </artifact>
 
                 <!-- pvmanager-plugins from reactor -->
                 <artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -300,7 +300,7 @@
                   <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:xaos:0.2.1</id>
+                  <id>se.europeanspallationsource:xaos:0.2.2</id>
                 </artifact>
 
                 <!-- pvmanager-plugins from reactor -->

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -288,13 +288,13 @@
                   <id>org.fxmisc.wellbehaved:wellbehavedfx:0.3.1</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.4</id>
+                  <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.5</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.knobs:1.0.11</id>
+                  <id>se.europeanspallationsource:javafx.control.knobs:1.0.12</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.medusa:7.9.7</id>
+                  <id>se.europeanspallationsource:javafx.control.medusa:8.0.0</id>
                 </artifact>
                 <artifact>
                   <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -300,7 +300,7 @@
                   <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:xaos:0.2.2</id>
+                  <id>se.europeanspallationsource:xaos:0.2.3</id>
                 </artifact>
 
                 <!-- pvmanager-plugins from reactor -->

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -300,7 +300,7 @@
                   <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:xaos:0.2.0</id>
+                  <id>se.europeanspallationsource:xaos:0.2.1</id>
                 </artifact>
 
                 <!-- pvmanager-plugins from reactor -->

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -299,6 +299,9 @@
                 <artifact>
                   <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>
                 </artifact>
+                <artifact>
+                  <id>se.europeanspallationsource:xaos:0.2.0</id>
+                </artifact>
 
                 <!-- pvmanager-plugins from reactor -->
                 <artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -279,13 +279,13 @@
                   <id>org.fxmisc.flowless:flowless:0.6</id>
                 </artifact>
                 <artifact>
-                  <id>org.fxmisc.richtext:richtextfx:0.8.1</id>
+                  <id>org.fxmisc.richtext:richtextfx:0.8.2</id>
                 </artifact>
                 <artifact>
-                  <id>org.fxmisc.undo:undofx:1.3.1</id>
+                  <id>org.fxmisc.undo:undofx:2.0.0</id>
                 </artifact>
                 <artifact>
-                  <id>org.fxmisc.wellbehaved:wellbehavedfx:0.3</id>
+                  <id>org.fxmisc.wellbehaved:wellbehavedfx:0.3.1</id>
                 </artifact>
                 <artifact>
                   <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.4</id>


### PR DESCRIPTION
Added the [XAOS](https://github.com/ESSICS/XAOS) library ver. 0.2.3, where SVG files are translated in pure JavaFX graph.

**Note:** this is a prerequisite for [#372](https://github.com/kasemir/org.csstudio.display.builder/pull/372).