### PR TITLE
Need to suppress com.sun.webkit in additon to com.sun.javafx

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -262,7 +262,7 @@
                   <id>org.controlsfx:controlsfx:8.40.14</id>
                   <override>true</override>
                   <instructions>
-                    <Import-Package>!com.sun.javafx.*,*</Import-Package>
+                    <Import-Package>!com.sun.*,!javafx.*,*</Import-Package>
                   </instructions>
                 </artifact>
                 <artifact>


### PR DESCRIPTION
Follow-up to #68 : Removing `com.sun.*` instead of just `com.sun.javafx.*` imports because com.sun.webkit causes the same problems as com.sun.javafx.
All are classes which are used with Java 8.
With Java 9, there's different, public API.