### PR TITLE
CSSTUDIO-721: fixing random colours

### DIFF
--- a/epics/plugins/org.csstudio.platform.libs.epics/.classpath
+++ b/epics/plugins/org.csstudio.platform.libs.epics/.classpath
@@ -23,11 +23,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="target/sources">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -261,6 +261,14 @@
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.14</id>
                 </artifact>
+<!--
+	Not possible to use JavaFxSVG 1.3.0 with the new instantiaion method
+		SvgImageLoaderFactory.install(new PrimitiveDimensionProvider());
+	because of conflicts loading org.apache.batic... classes
+		Exception ... java.lang.NoClassDefFoundError: org/apache/batik/dom/svg/SVGDocumentFactory
+		Caused by: java.lang.ClassNotFoundException: org.apache.batik.dom.svg.SVGDocumentFactory cannot be found by org.apache.xmlgraphics.batik-anim_1.8.0
+	because of coexistence of ver. 1.7 and 1.8 of org.apache.batik.dom.svg.
+-->
                 <artifact>
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
                 </artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -265,6 +265,21 @@
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
                 </artifact>
                 <artifact>
+                  <id>org.reactfx:reactfx:2.0-M5</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.flowless:flowless:0.6</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.richtext:richtextfx:0.8.1</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.undo:undofx:1.3.1</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.wellbehaved:wellbehavedfx:0.3</id>
+                </artifact>
+                <artifact>
                   <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.4</id>
                 </artifact>
                 <artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -305,7 +305,7 @@
                   <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:xaos:0.2.6</id>
+                  <id>se.europeanspallationsource:xaos:0.2.7</id>
                 </artifact>
 
                 <!-- pvmanager-plugins from reactor -->

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -261,17 +261,6 @@
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.14</id>
                 </artifact>
-<!--
-	Not possible to use JavaFxSVG 1.3.0 with the new instantiaion method
-		SvgImageLoaderFactory.install(new PrimitiveDimensionProvider());
-	because of conflicts loading org.apache.batic... classes
-		Exception ... java.lang.NoClassDefFoundError: org/apache/batik/dom/svg/SVGDocumentFactory
-		Caused by: java.lang.ClassNotFoundException: org.apache.batik.dom.svg.SVGDocumentFactory cannot be found by org.apache.xmlgraphics.batik-anim_1.8.0
-	because of coexistence of ver. 1.7 and 1.8 of org.apache.batik.dom.svg.
--->
-                <artifact>
-                  <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
-                </artifact>
                 <artifact>
                   <id>org.reactfx:reactfx:2.0-M5</id>
                 </artifact>


### PR DESCRIPTION
Updated XAOS to ver. 0.2.7.
The main change is a fix in a shared styles cached used by the SVG loader that was now made per-loader instead of static.
**Note:** it must be followed by [org.csstudio.display.builder#396](https://github.com/kasemir/org.csstudio.display.builder/pull/396).