### PR TITLE
CSSTUDIO-744: removing build dependency from DIIRT project

### DIFF
--- a/epics/plugins/org.csstudio.platform.libs.epics/.classpath
+++ b/epics/plugins/org.csstudio.platform.libs.epics/.classpath
@@ -23,11 +23,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="target/sources">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -261,6 +261,14 @@
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.14</id>
                 </artifact>
+<!--
+	Not possible to use JavaFxSVG 1.3.0 with the new instantiaion method
+		SvgImageLoaderFactory.install(new PrimitiveDimensionProvider());
+	because of conflicts loading org.apache.batic... classes
+		Exception ... java.lang.NoClassDefFoundError: org/apache/batik/dom/svg/SVGDocumentFactory
+		Caused by: java.lang.ClassNotFoundException: org.apache.batik.dom.svg.SVGDocumentFactory cannot be found by org.apache.xmlgraphics.batik-anim_1.8.0
+	because of coexistence of ver. 1.7 and 1.8 of org.apache.batik.dom.svg.
+-->
                 <artifact>
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
                 </artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -257,7 +257,89 @@
                   </instructions>
                 </artifact>
 
-                <!-- JavaFX libraries -->
+
+				<!-- DIIRT libraries -->
+                <artifact>
+                  <id>org.diirt:datasource:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-extra:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-file:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-file-json:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-formula:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-graphene:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-integration:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-loc:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-sample:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-sim:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-sys:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-test:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:datasource-vtype:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:graphene:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:graphene-profile:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:service:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:service-exec:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:service-jdbc:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:diirt-util:3.1.7</id>
+                </artifact>
+				<artifact>
+                  <id>org.diirt:vtype:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt:vtype-json:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt.javafx:javafx:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt.javafx:tools:3.1.7</id>
+                </artifact>
+				<artifact>
+                  <id>org.diirt.support:diirt-ca:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt.support:diirt-cf:3.1.7</id>
+                </artifact>
+                <artifact>
+                  <id>org.diirt.support:diirt-pva:3.1.7</id>
+                </artifact>
+
+
+				<!-- JavaFX libraries -->
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.14</id>
                   <override>true</override>
@@ -307,6 +389,7 @@
                 <artifact>
                   <id>se.europeanspallationsource:xaos:0.2.7</id>
                 </artifact>
+
 
                 <!-- pvmanager-plugins from reactor -->
                 <artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -265,6 +265,21 @@
                   <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
                 </artifact>
                 <artifact>
+                  <id>org.reactfx:reactfx:2.0-M5</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.flowless:flowless:0.6</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.richtext:richtextfx:0.8.1</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.undo:undofx:1.3.1</id>
+                </artifact>
+                <artifact>
+                  <id>org.fxmisc.wellbehaved:wellbehavedfx:0.3</id>
+                </artifact>
+                <artifact>
                   <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.4</id>
                 </artifact>
                 <artifact>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -261,17 +261,6 @@
                 <artifact>
                   <id>org.controlsfx:controlsfx:8.40.14</id>
                 </artifact>
-<!--
-	Not possible to use JavaFxSVG 1.3.0 with the new instantiaion method
-		SvgImageLoaderFactory.install(new PrimitiveDimensionProvider());
-	because of conflicts loading org.apache.batic... classes
-		Exception ... java.lang.NoClassDefFoundError: org/apache/batik/dom/svg/SVGDocumentFactory
-		Caused by: java.lang.ClassNotFoundException: org.apache.batik.dom.svg.SVGDocumentFactory cannot be found by org.apache.xmlgraphics.batik-anim_1.8.0
-	because of coexistence of ver. 1.7 and 1.8 of org.apache.batik.dom.svg.
--->
-                <artifact>
-                  <id>de.codecentric.centerdevice:javafxsvg:1.2.1</id>
-                </artifact>
                 <artifact>
                   <id>org.reactfx:reactfx:2.0-M5</id>
                 </artifact>


### PR DESCRIPTION
Added DIIRT 3.1.7 dependency into the `maven-osgi-bundles` project, so that building DIIRT project itself is no more a needed step.