### PR TITLE
Medusa library updated to ver. 8.0.1.

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -381,7 +381,7 @@
                   <id>se.europeanspallationsource:javafx.control.knobs:1.0.13</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.medusa:8.0.0</id>
+                  <id>se.europeanspallationsource:javafx.control.medusa:8.0.1</id>
                 </artifact>
                 <artifact>
                   <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>


### PR DESCRIPTION
Medusa library updated with few changes from Han Solo and a main change by myself to fix the following problem: if a GAUGE (used in Display Builder Meter widget) has a negative minimum value and a non-integer minor tick size it can happen minor ticks not being displayed:

<img width="382" alt="screenshot 2018-10-23 at 12 36 05" src="https://user-images.githubusercontent.com/10833922/47361451-3bd39b80-d6d2-11e8-80ae-3416a3de6fb3.png">

after the patch:

<img width="382" alt="screenshot 2018-10-23 at 12 37 07" src="https://user-images.githubusercontent.com/10833922/47361424-30807000-d6d2-11e8-959e-11770b5ebcba.png">
