### PR TITLE
Updated ESS libraries for Java 9+ compatibility.

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -375,16 +375,16 @@
                   <id>org.fxmisc.wellbehaved:wellbehavedfx:0.3.3</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.6</id>
+                  <id>se.europeanspallationsource:javafx.control.controlled-knobs:1.0.7</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.knobs:1.0.13</id>
+                  <id>se.europeanspallationsource:javafx.control.knobs:1.0.14</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.medusa:8.0.1</id>
+                  <id>se.europeanspallationsource:javafx.control.medusa:8.0.2</id>
                 </artifact>
                 <artifact>
-                  <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.3</id>
+                  <id>se.europeanspallationsource:javafx.control.thumbwheel:1.0.4</id>
                 </artifact>
                 <artifact>
                   <id>se.europeanspallationsource:xaos:0.2.7</id>


### PR DESCRIPTION
Updated ESS libraries, whose MANIFEST.mf now contains the Automatic-Module-Name declaration for Java 9+ compatibility:

- [ESS-MEDUSA](https://github.com/ESSICS/ESS-MEDUSA) ver. 8.0.2;
- [KNOBS](https://github.com/ESSICS/KNOBS) ver. 1.0.14;
- [Controlled-KNOBS](https://github.com/ESSICS/Controlled-KNOBS) to ver. 1.0.7;
- [THUMBWHEEL](https://github.com/ESSICS/THUMBWHEEL) to ver 1.0.4.

[XAOS](https://github.com/ESSICS/XAOS) is left to ver. 0.2.7 because the new version (0.3.0) is already module-based and compiled for Java 11. It can be used once CS-Studio will be ported to Java 11.