### PR TITLE
Remove the reficio.org repo as it is not needed. (4.5.x)

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>lt.velykis.maven</groupId>
         <artifactId>pde-target-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <executions>
           <execution>
             <id>pde-target</id>
@@ -417,11 +417,4 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>reficio</id>
-      <url>http://repo.reficio.org/maven/</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>


### PR DESCRIPTION
The same plugins are available on Maven Central.
Update pde-target-maven-plugin to the latest version.

@berryma4 see #80 and #81