### PR TITLE
Split of Batik bundles

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -186,7 +186,76 @@
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-all:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-bridge:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-dom:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-svg-dom:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-transcoder:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.xmlgraphics.batik-codec;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+		<artifact>
+                  <id>org.apache.xmlgraphics:batik-codec:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+		<artifact>
+                  <id>org.apache.xmlgraphics:batik-xml:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-awt-util:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-anim:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-gvt:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-script:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-ext:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
+                </artifact>
+                <artifact>
+                  <id>org.apache.xmlgraphics:batik-parser:1.10</id>
+                  <instructions>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                  </instructions>
                 </artifact>
                 <artifact>
                   <id>javax.xml.bind:jaxb-api:2.3.1</id>


### PR DESCRIPTION
Hi,

At ITER we have solved the issue were SVGs were not being shown in BOY. To avoid the conflict with the Batik bundles loaded by Eclipse, we had to use the Batik's subjars. We had to add the necessary "Require-Bundle"s as p2-maven-plugin does not.

This solves part of https://github.com/ControlSystemStudio/cs-studio/issues/2448